### PR TITLE
Completes User Stories: Create, Update, Delete an item

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -6,4 +6,30 @@ class Api::V1::ItemsController < ApplicationController
   def show
     render json: ItemSerializer.new(Item.find(params[:id]))
   end
+
+  def create
+    item = Item.create!(item_params)
+    render json: ItemSerializer.new(item), status: 201 if item.save
+  end
+
+  def update
+    item = Item.find(params[:id])
+    if Merchant.exists?(item_params[:merchant_id]) || !item_params[:merchant_id]
+      item.update(item_params)
+      render json: ItemSerializer.new(item)
+    else
+      render json: { errors: {execption: 'Merchant ID is invalid' }}, status: 400
+    end
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.delete
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,12 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :handle_error_404
+  rescue_from ActiveRecord::RecordInvalid, with: :handle_error_400
 
   def handle_error_404(error)
     render json: { errors: { exception: error.to_s} }, status: :not_found
+  end
+
+  def handle_error_400(error)
+    render json: { errors: {execption: error.to_s} }, status: 400
   end
 end


### PR DESCRIPTION
- Added happy and sad path testing for #create, #update, #destroy in the items_request_spec 
- `ApplicationController` now can rescue from ActiveRecord Invalid input with a 400 error
- `ItemsController` has #create, #update, #destroy methods with status 201 logic for a successful item creation and status 400 logic for an invalid merchant_id associated with the item being updated. 