### PR TITLE
Completes User Story: Get one item's merchant

### DIFF
--- a/app/controllers/api/v1/item_merchants_controller.rb
+++ b/app/controllers/api/v1/item_merchants_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ItemMerchantsController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Item.find(params[:item_id]).merchant)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
         resources :items, only: [:index], controller: 'merchant_items'
       end
 
-      resources :items 
+      resources :items do
+        resources :merchant, only: [:index], controller: 'item_merchants'
+      end
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -230,4 +230,31 @@ RSpec.describe "Items API" do
       end
     end
   end
+
+  describe 'get merchant' do
+    describe 'happy path' do
+      it "returns the merchant of the specified item as a json object" do
+        id = create(:item).id
+
+        get api_v1_item_merchant_index_path(id)
+        merchant = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(200)
+        expect(merchant).to have_key(:data)
+        expect(merchant[:data]).to have_key(:attributes)
+        expect(merchant[:data][:attributes][:name]).to be_a String
+      end
+    end
+
+    describe 'sad path' do
+      it 'returns a 404 status error if the item is not found' do
+        get api_v1_item_merchant_index_path(1)
+        result = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(404)
+        expect(result).to have_key(:errors)
+        expect(result[:errors][:exception]).to eq("Couldn't find Item with 'id'=1")
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Adds one happy path and one sad path test to the `items_request_spec` 
- Updates routes to have `merchant` as a nested resource for `items` and to have the route point to the index action in the newly created `ItemMerchantsController` 
- Utilizes `MerchantSerializer` and finds the merchant data to serialize by findings the item by item_id and then calling `.merchant` to find that items associated merchant (This is in the `ItemMerchantsController`)