### PR TITLE
Completes: Edge Cases for Part 1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,10 @@ class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordInvalid, with: :error_400
 
   def error_404(error)
-    render json: { errors: { exception: error.to_s} }, status: :not_found
+    render json: { error: { exception: error.to_s} }, status: 404
   end
 
   def error_400(error)
-    render json: { errors: {execption: error.to_s} }, status: 400
+    render json: { error: {execption: error.to_s} }, status: 400
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   validates_presence_of(:description)
   validates_presence_of(:unit_price)
   validates :unit_price, numericality: { greater_than: 0.0 }
+  validates :merchant_id, numericality: true
   #class methods
   def self.find_all_items_by_name(query)
     where('name ILIKE ?', "%#{query}%")

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Item do
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:unit_price) }
     it { should validate_numericality_of(:unit_price).is_greater_than(0.0) }
+    it { should validate_numericality_of(:merchant_id) }
   end
 
   describe 'class methods' do

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe "Items API" do
 
         expect(response.status).to eq(404)
 
-        expect(no_item).to have_key(:errors)
-        expect(no_item[:errors][:exception]).to eq("Couldn't find Item with 'id'=1")
+        expect(no_item).to have_key(:error)
+        expect(no_item[:error][:exception]).to eq("Couldn't find Item with 'id'=1")
       end
     end
   end
@@ -252,8 +252,8 @@ RSpec.describe "Items API" do
         result = JSON.parse(response.body, symbolize_names: true)
 
         expect(response.status).to eq(404)
-        expect(result).to have_key(:errors)
-        expect(result[:errors][:exception]).to eq("Couldn't find Item with 'id'=1")
+        expect(result).to have_key(:error)
+        expect(result[:error][:exception]).to eq("Couldn't find Item with 'id'=1")
       end
     end
   end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -59,8 +59,8 @@ describe "Merchants API" do
 
         expect(response.status).to eq(404)
 
-        expect(no_merchant).to have_key(:errors)
-        expect(no_merchant[:errors][:exception]).to eq("Couldn't find Merchant with 'id'=1")
+        expect(no_merchant).to have_key(:error)
+        expect(no_merchant[:error][:exception]).to eq("Couldn't find Merchant with 'id'=1")
       end
     end
   end
@@ -98,8 +98,8 @@ describe "Merchants API" do
           get api_v1_merchant_items_path(1)
 
           expect(response.status).to eq(404)
-          expect(JSON.parse(response.body, symbolize_names: true)).to have_key(:errors)
-          expect(JSON.parse(response.body, symbolize_names: true)[:errors][:exception]).to eq("Couldn't find Merchant with 'id'=1")
+          expect(JSON.parse(response.body, symbolize_names: true)).to have_key(:error)
+          expect(JSON.parse(response.body, symbolize_names: true)[:error][:exception]).to eq("Couldn't find Merchant with 'id'=1")
         end
       end
     end


### PR DESCRIPTION
- The crux of getting the app to pass the Merchant's Items edge case test on Postman was changing the key in the rendering if json to `:error` rather than `:errors`. 
- This active_record rescue is located in `ApplicationController`. 
- items_request_spec and merchants_request_spec updated to reflect the change in syntax in the json error rendering